### PR TITLE
refactor: #58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "opentelemetry",
+ "rstest",
  "serde",
  "serde_json",
  "strum 0.27.2",
@@ -1404,6 +1405,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2795,6 +2802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "relay"
 version = "0.1.0"
 dependencies = [
@@ -2887,6 +2900,35 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.111",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sea-orm = { version = "1.1.19", features = [
 actix-web = "4.12.1"
 tokio = "1.49.0"
 tokio-util = "0.7.18"
+rstest = "0.26.1"
 
 [dependencies]
 infrastructure = { workspace = true }

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ add: ## 依存クレートを追加 (使用例: make add d=serde)
 
 # テスト実行
 test: ## アプリケーションのテスト
-	$(DOCKER_COMPOSE) run --rm $(APP_SERVICE) cargo test
+	$(DOCKER_COMPOSE) run --rm $(APP_SERVICE) cargo test --workspace
 
 # キャッシュのクリーンアップなど
 clean: ## ボリュームの削除, target ディレクトリの削除

--- a/libs/domain/Cargo.toml
+++ b/libs/domain/Cargo.toml
@@ -23,3 +23,6 @@ tracing-opentelemetry = { workspace = true }
 [features]
 # 必要に応じて DTO 用のシリアライズ設定などを切り替え可能にする
 default = []
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/libs/domain/src/shared/domain_event.rs
+++ b/libs/domain/src/shared/domain_event.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::user::UserEvent;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, derive_more::Display)]
 pub enum DomainEvent {
     UserEvent(UserEvent),
     // 将来的に他のイベントタイプも追加可能
@@ -11,5 +11,53 @@ pub enum DomainEvent {
 impl From<UserEvent> for DomainEvent {
     fn from(event: UserEvent) -> Self {
         DomainEvent::UserEvent(event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use crate::user::{self, EmailTrait, UnverifiedEmail, UserCreatedEvent};
+
+    use super::*;
+
+    #[rstest]
+    #[case(
+        UserEvent::Created(UserCreatedEvent {
+            user_id: Uuid::new_v4().into(),
+            email: UnverifiedEmail::new("user@example.com").unwrap(),
+            registered_at: Utc::now(),
+        }),
+        "UserEvent::Created"
+    )]
+    #[case(
+        UserEvent::Suspended(user::UserSuspendedEvent {
+            user_id: Uuid::new_v4().into(),
+            reason: "Violation of terms".to_string(),
+            suspended_at: Utc::now(),
+        }),
+        "UserEvent::Suspended"
+    )]
+    #[case(
+        UserEvent::Unlocked(user::UserUnlockedEvent {
+            user_id: Uuid::new_v4().into(),
+            unlocked_at: Utc::now(),
+        }),
+        "UserEvent::Unlocked"
+    )]
+    #[case(
+        UserEvent::Deactivated(user::UserDeactivatedEvent {
+            user_id: Uuid::new_v4().into(),
+            deactivated_at: Utc::now(),
+        }),
+        "UserEvent::Deactivated"
+    )]
+    fn test_domain_event_display(#[case] user_event: UserEvent, #[case] display_str: &str) {
+        let domain_event = DomainEvent::from(user_event);
+        assert_eq!(domain_event.to_string(), display_str);
     }
 }

--- a/libs/domain/src/user/events.rs
+++ b/libs/domain/src/user/events.rs
@@ -1,10 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use strum::AsRefStr;
 
 use crate::user::{UnverifiedEmail, UserId};
 
-#[derive(Deserialize, Serialize, Debug, Clone, AsRefStr)]
+#[derive(Deserialize, Serialize, Debug, Clone, strum::Display)]
 #[strum(prefix = "UserEvent::")]
 pub enum UserEvent {
     Created(UserCreatedEvent),

--- a/libs/infrastructure/src/persistence/seaorm/repository/outbox_repository.rs
+++ b/libs/infrastructure/src/persistence/seaorm/repository/outbox_repository.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use async_trait::async_trait;
 use domain::shared::{
     domain_event::DomainEvent,
@@ -24,24 +22,13 @@ where
     _marker: std::marker::PhantomData<T>,
 }
 
-struct EventTypeFormatter<'a>(&'a DomainEvent);
-
-impl fmt::Display for EventTypeFormatter<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let event_type = match self.0 {
-            DomainEvent::UserEvent(user_event) => user_event.as_ref(),
-        };
-        write!(f, "{}", event_type)
-    }
-}
-
 fn get_active_model_from_event(
     event: OutboxEvent,
 ) -> Result<outbox_entity::ActiveModel, OutboxRepositoryError> {
     let payload = serde_json::to_value(event.domain_event())
         .map_err(|e| OutboxRepositoryError::Persistence(e.into()))?;
 
-    let event_type = EventTypeFormatter(event.domain_event()).to_string();
+    let event_type = event.domain_event().to_string();
 
     Ok(outbox_entity::ActiveModel {
         id: Set(event.id().into()),


### PR DESCRIPTION
- strum::Display と derive_more::Display を活用してdomain_event の文字列化を自動化
- rstest の導入